### PR TITLE
Moved composer-config-output directory to our own `runtime` folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
         "branch-alias": {
             "dev-master": "3.0.x-dev"
         },
+        "config-plugin-output-dir": "runtime/config-plugin-output-dir",
         "config-plugin": {
             "common": "config/common.php",
             "params": [

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "branch-alias": {
             "dev-master": "3.0.x-dev"
         },
-        "config-plugin-output-dir": "runtime/cache/config",
+        "config-plugin-output-dir": "runtime/build/config",
         "config-plugin": {
             "common": "config/common.php",
             "params": [

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "branch-alias": {
             "dev-master": "3.0.x-dev"
         },
-        "config-plugin-output-dir": "runtime/config-plugin-output-dir",
+        "config-plugin-output-dir": "runtime/cache/config",
         "config-plugin": {
             "common": "config/common.php",
             "params": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️

At now hiqdev/composer-config-plugin will write into our own `runtime` directory instead of `vendor/hiqdev/composer-config-plugin/composer-config-output`