### PR TITLE
Fix access to runtime

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     },
     "scripts": {
         "post-install-cmd": [
-            "chmod -R 0777 runtime"
+            "php -r \"chmod('runtime',0777);\""
          ]
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,11 @@
             "App\\": "src"
         }
     },
+    "scripts": {
+        "post-install-cmd": [
+            "chmod -R 0777 runtime"
+         ]
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "3.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -61,8 +61,8 @@
     },
     "scripts": {
         "post-install-cmd": [
-            "php -r \"chmod('runtime',0777);\""
-         ]
+            "App\\Installer::postInstall"
+        ]
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -60,8 +60,8 @@
         }
     },
     "scripts": {
-        "post-install-cmd": [
-            "App\\Installer::postInstall"
+        "post-update-cmd": [
+            "App\\Installer::postUpdate"
         ]
     },
     "extra": {

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -20,10 +20,7 @@ final class Installer
     {
         chmod($path, $mode);
         $iterator = new RIterator(
-            new DirIterator(
-                $path,
-                FSIterator::SKIP_DOTS | FSIterator::CURRENT_AS_PATHNAME
-            ),
+            new DirIterator($path, FSIterator::SKIP_DOTS | FSIterator::CURRENT_AS_PATHNAME),
             RIterator::SELF_FIRST
         );
         foreach ($iterator as $item) {

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -11,7 +11,8 @@ class Installer
         self::rchmod('runtime', 0777);
     }
 
-    private static function rchmod(string $path, int $mode): void {
+    private static function rchmod(string $path, int $mode): void
+    {
         $dir = new \DirectoryIterator($path);
         foreach ($dir as $item) {
             chmod($item->getPathname(), $mode);

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -15,12 +15,14 @@ final class Installer
 
     private static function chmodRecursive(string $path, int $mode): void
     {
+        chmod($path, $mode);
         $dir = new \DirectoryIterator($path);
         foreach ($dir as $item) {
-            if (!$item->isDot()) {
-                chmod($path, $mode);
+            if ($item->isDot()) {
+                continue;
             }
-            if ($item->isDir() && !$item->isDot()) {
+            chmod($path, $mode);
+            if ($item->isDir()) {
                 self::chmodRecursive($item->getPathname(), $mode);
             }
         }

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App;
 
 use Composer\Script\Event;
-use RecursiveIteratorIterator;
+use RecursiveIteratorIterator as RIterator;
+use FilesystemIterator as FSIterator;
+use RecursiveDirectoryIterator as DirIterator;
 
 final class Installer
 {
@@ -17,12 +19,15 @@ final class Installer
     private static function chmodRecursive(string $path, int $mode): void
     {
         chmod($path, $mode);
-        $iterator = new RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path), RecursiveIteratorIterator::SELF_FIRST);
+        $iterator = new RIterator(
+            new DirIterator(
+                $path,
+                FSIterator::SKIP_DOTS | FSIterator::CURRENT_AS_PATHNAME
+            ),
+            RIterator::SELF_FIRST
+        );
         foreach ($iterator as $item) {
-            $filename = $item->getFileName();
-            if (!($filename === '.' || $filename === '..')) {
-                chmod((string) $item, $mode);
-            }
+            chmod($item, $mode);
         }
     }
 }

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -1,23 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use Composer\Script\Event;
 
-class Installer
+final class Installer
 {
-    public static function postInstall(Event $event): void
+    public static function postUpdate(Event $event = null): void
     {
-        self::rchmod('runtime', 0777);
+        self::chmodRecursive('runtime', 0777);
     }
 
-    private static function rchmod(string $path, int $mode): void
+    private static function chmodRecursive(string $path, int $mode): void
     {
         $dir = new \DirectoryIterator($path);
         foreach ($dir as $item) {
             chmod($item->getPathname(), $mode);
             if ($item->isDir() && !$item->isDot()) {
-                self::rchmod($item->getPathname(), $mode);
+                self::chmodRecursive($item->getPathname(), $mode);
             }
         }
     }

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -18,7 +18,7 @@ final class Installer
     {
         chmod($path, $mode);
         $iterator = new RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path), RecursiveIteratorIterator::SELF_FIRST);
-        foreach($iterator as $item) {
+        foreach ($iterator as $item) {
             $filename = $item->getFileName();
             if (!($filename === '.' || $filename === '..')) {
                 chmod((string) $item, $mode);

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -14,7 +14,7 @@ final class Installer
     }
 
     private static function chmodRecursive(string $path, int $mode): void
-    {\
+    {
         $dir = new \DirectoryIterator($path);
         foreach ($dir as $item) {
             if (!$item->isDot()) {

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -14,10 +14,12 @@ final class Installer
     }
 
     private static function chmodRecursive(string $path, int $mode): void
-    {
+    {\
         $dir = new \DirectoryIterator($path);
         foreach ($dir as $item) {
-            chmod($item->getPathname(), $mode);
+            if (!$item->isDot()) {
+                chmod($path, $mode);
+            }
             if ($item->isDir() && !$item->isDot()) {
                 self::chmodRecursive($item->getPathname(), $mode);
             }

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App;
 
 use Composer\Script\Event;
+use RecursiveIteratorIterator;
 
 final class Installer
 {
@@ -16,14 +17,11 @@ final class Installer
     private static function chmodRecursive(string $path, int $mode): void
     {
         chmod($path, $mode);
-        $dir = new \DirectoryIterator($path);
-        foreach ($dir as $item) {
-            if ($item->isDot()) {
-                continue;
-            }
-            chmod($path, $mode);
-            if ($item->isDir()) {
-                self::chmodRecursive($item->getPathname(), $mode);
+        $iterator = new RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path), RecursiveIteratorIterator::SELF_FIRST);
+        foreach($iterator as $item) {
+            $filename = $item->getFileName();
+            if (!($filename === '.' || $filename === '..')) {
+                chmod((string) $item, $mode);
             }
         }
     }

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App;
+
+use Composer\Script\Event;
+use Composer\Installer\PackageEvent;
+
+class Installer
+{
+    public static function postInstall(Event $event): void 
+    {
+        self::rchmod('runtime', 0777);
+    }
+
+    private static function rchmod(string $path, int $mode): void {
+        $dir = new \DirectoryIterator($path); 
+        foreach ($dir as $item) { 
+            chmod($item->getPathname(), $mode); 
+            if ($item->isDir() && !$item->isDot()) { 
+                self::rchmod($item->getPathname(), $mode); 
+            }
+        }
+    }
+}

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -3,21 +3,20 @@
 namespace App;
 
 use Composer\Script\Event;
-use Composer\Installer\PackageEvent;
 
 class Installer
 {
-    public static function postInstall(Event $event): void 
+    public static function postInstall(Event $event): void
     {
         self::rchmod('runtime', 0777);
     }
 
     private static function rchmod(string $path, int $mode): void {
-        $dir = new \DirectoryIterator($path); 
-        foreach ($dir as $item) { 
-            chmod($item->getPathname(), $mode); 
-            if ($item->isDir() && !$item->isDot()) { 
-                self::rchmod($item->getPathname(), $mode); 
+        $dir = new \DirectoryIterator($path);
+        foreach ($dir as $item) {
+            chmod($item->getPathname(), $mode);
+            if ($item->isDir() && !$item->isDot()) {
+                self::rchmod($item->getPathname(), $mode);
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

When run application via docker-compose.yml Builder throw Exception due to insufficient access to runtime folder. This PR fix that