### PR TITLE
reconstruct App\Controller->render make it easy to understand.

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -46,7 +46,7 @@ abstract class Controller implements ViewContextInterface
         $content = $this->view->render($view, $parameters, $this);
         $user = $this->user->getIdentity();
         $layout = $this->findLayoutFile($this->layout);
-        
+
         if ($layout === null) {
             return $content;
         }

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -33,10 +33,7 @@ abstract class Controller implements ViewContextInterface
 
     protected function render(string $view, array $parameters = []): ResponseInterface
     {
-        $self = $this;
-        $contentRenderer = static function () use ($view, $parameters, $self) {
-            return $self->renderProxy($view, $parameters);
-        };
+        $contentRenderer = fn () => $this->renderProxy($view, $parameters);
 
         return $this->responseFactory->createResponse($contentRenderer);
     }

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -38,7 +38,7 @@ abstract class Controller implements ViewContextInterface
         return $this->responseFactory->createResponse($contentRenderer);
     }
 
-    private function renderProxy($view, $parameters): string
+    private function renderProxy(string $view, array $parameters = []): string
     {
         $content = $this->view->render($view, $parameters, $this);
         $user = $this->user->getIdentity();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 

`$controller` => `$self` .  just for replace keyword `this` to `self` for closure . reduce to think `$controller` may has other useful thing.

```
return $controller->renderContent($controller->view->render($view, $parameters, $controller));
 ```
=>
```
return $self->renderProxy($view, $parameters); 
```

// closure for proxy,use parent var. 
// reduce a level(hierarchy?) .
```
if ($layout === null) {
    return $content;
}
```
// return early . reduce a thinking stack.
