### PR TITLE
Add yiisoft/http to dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "yiisoft/factory": "^3.0@dev",
         "yiisoft/form": "^1.0@dev",
         "yiisoft/html": "^3.0@dev",
+        "yiisoft/http": "^1.1",
         "yiisoft/injector": "^1.0",
         "yiisoft/log": "^3.0@dev",
         "yiisoft/log-target-file": "^3.0@dev",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

`yiisoft/http` used in routes configuration.
