### PR TITLE
Remove dump functions from this package

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Yiisoft\Files\FileHelper;
-use Yiisoft\VarDumper\VarDumper;
 
 function shouldRebuildConfigs(): bool
 {
@@ -17,23 +16,4 @@ function shouldRebuildConfigs(): bool
     $sourceTime = FileHelper::lastModifiedTime($sourceDirectory);
     $buildTime = FileHelper::lastModifiedTime($buildDirectory);
     return $buildTime < $sourceTime;
-}
-
-if (!function_exists('d')) {
-    function d(...$variables)
-    {
-        foreach ($variables as $variable) {
-            VarDumper::dump($variable, 10, PHP_SAPI !== 'cli');
-        }
-    }
-}
-
-if (!function_exists('dd')) {
-    function dd(...$variables)
-    {
-        foreach ($variables as $variable) {
-            VarDumper::dump($variable, 10, PHP_SAPI !== 'cli');
-        }
-        die();
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Dump functions were moved to the `yiisoft/var-dumper` package:
https://github.com/yiisoft/var-dumper/blob/master/src/functions.php
