### PR TITLE
fix: Uncaught TypeError

### DIFF
--- a/src/Contact/ContactController.php
+++ b/src/Contact/ContactController.php
@@ -39,7 +39,7 @@ class ContactController
     ): ResponseInterface {
         $body = $request->getParsedBody();
         $form = new ContactForm();
-        if (($request->getMethod() === Method::POST) && $form->load($body) && $form->validate($validator)) {
+        if (($request->getMethod() === Method::POST) && $form->load((array)$body) && $form->validate($validator)) {
             $this->mailer->send($form, $request);
 
             return $this->responseFactory


### PR DESCRIPTION
Argument must be of type array.
`\Psr\Http\Message\ServerRequestInterface::getParsedBody` could be `null|object|array`