### PR TITLE
Use new version of Faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "codeception/codeception": "^4.1.9",
         "codeception/module-asserts": "@dev",
         "codeception/module-phpbrowser": "@dev",
-        "fzaninotto/faker": "^1.9",
+        "fakerphp/faker": "^1.13.0",
         "phpunit/phpunit": "^9.4",
         "roave/infection-static-analysis-plugin": "^1.5",
         "roave/security-advisories": "dev-master",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | 

Original faker library is not compatible with php 8 and it is not maintained anymore.
So I suggest to use maintained and compatible version.